### PR TITLE
Allows spaces in paths

### DIFF
--- a/Core/InputRead.cpp
+++ b/Core/InputRead.cpp
@@ -1075,7 +1075,8 @@ int InputRead::parse_line_old_file(key_word_help kwh, std::string &arg1, unsigne
 
 	io_keyline.str(keyline);
 
-	io_keyline >> word >> str1;
+	getline(io_keyline, word, '\t');
+	getline(io_keyline, str1, '\t');
 
 	std::ifstream old_file(str1.c_str());
 


### PR DESCRIPTION
Changed InputRead to split tab delimited line to allow spaces in paths