### PR TITLE
Input path parser fix

### DIFF
--- a/Core/InputRead.cpp
+++ b/Core/InputRead.cpp
@@ -1075,8 +1075,11 @@ int InputRead::parse_line_old_file(key_word_help kwh, std::string &arg1, unsigne
 
 	io_keyline.str(keyline);
 
-	getline(io_keyline, word, '\t');
-	getline(io_keyline, str1, '\t');
+	while (word == "")
+		getline(io_keyline, word, '\t');
+
+	while (str1 == "")
+		getline(io_keyline, str1, '\t');
 
 	std::ifstream old_file(str1.c_str());
 
@@ -1110,7 +1113,11 @@ int InputRead::parse_line_new_file(key_word_help kwh, std::string &arg1, bool re
 
 	io_keyline.str(keyline);
 
-	io_keyline >> word >> str1;
+	while (word == "")
+		getline(io_keyline, word, '\t');
+
+	while(str1=="")
+		getline(io_keyline, str1, '\t');
 
 	std::ofstream new_file(str1.c_str());
 

--- a/Core/dvc.cpp
+++ b/Core/dvc.cpp
@@ -304,8 +304,8 @@ int main(int argc, char *argv[])
 	sta_file << "number range fail = " << count_range << "\t(" << 100*((double)count_range/(double)count) << "%)\n";
 	sta_file << "number convg fail = " << count_convg << "\t(" << 100*((double)count_convg/(double)count) << "%)\n";
 
-	std::cin.get();
-	std::cin.get();
+	//std::cin.get();
+	//std::cin.get();
 
 	return 0;
 }


### PR DESCRIPTION
Updated parse_line_new_file() and parse_line_old_file() from InputRead.cpp
- Will parse paths containing spaces
- Parse input as tab delimited, will treat multiple tabs corrctly